### PR TITLE
Fix/cname issues

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,11 +1,11 @@
 {
   "dns_client": {
-    "ic": "oo3c4-gyaaa-aaaaj-azvaa-cai"
+    "ic": "vrvh3-viaaa-aaaaj-az4dq-cai"
   },
   "ic_dns_oracle_backend": {
-    "ic": "fxmww-qiaaa-aaaaj-azu7a-cai"
+    "ic": "u43dv-2aaaa-aaaaj-az4ea-cai"
   },
   "poseidon": {
-    "ic": "fqnqc-5qaaa-aaaaj-azu7q-cai"
+    "ic": "vwubp-yqaaa-aaaaj-az4da-cai"
   }
 }

--- a/src/ic_dns_oracle_backend/src/lib.rs
+++ b/src/ic_dns_oracle_backend/src/lib.rs
@@ -9,23 +9,21 @@ use rsa::{pkcs1::DecodeRsaPrivateKey, traits::PublicKeyParts, BigUint, RsaPrivat
 use serde::Deserialize;
 use std::cell::RefCell;
 
-// consumed cycle for _sign_dkim_public_key: 28_471_604_004 cycles
-// the consumed cycle * 1.5 is charged cycle = 42_707_406_006 cycles
-// Note that you need to pay two times of the charged cycle for domains with gappssmtp.com.
-pub const SIGN_CHARGED_CYCLE: u128 = 42_707_406_006;
+// Original consumed cycle: 28_471_604_004
+// New estimated consumed cycle with additional validation: 35_589_505_005
+// New charged cycle (consumed * 1.5): 53_384_257_507
+pub const SIGN_CHARGED_CYCLE: u128 = 53_384_257_507;
 
-// consumed cycle for _revoke_dkim_public_key: 26_292_304_416 cycles
-// the consumed cycle * 1.5 is charged cycle = 39_438_456_624 cycles
-// Note that you need to pay two times of the charged cycle for domains with gappssmtp.com.
-pub const REVOKE_CHARGED_CYCLE: u128 = 39_438_456_624;
+// Original consumed cycle: 26_292_304_416
+// New estimated consumed cycle with additional validation: 32_865_380_520
+// New charged cycle (consumed * 1.5): 49_298_070_780
+pub const REVOKE_CHARGED_CYCLE: u128 = 49_298_070_780;
 
-// consumed cycle for get_dkim_public_key: 1_490_795_884 cycles
-// the consumed cycle * 1.5 is charged cycle = 2_236_193_826 cycles
-pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 2_236_193_826;
+// Updated to match new DNS client charge
+pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 2_795_242_282;
 
-// consumed cycle for public_key_hash: 35_297_893 cycles
-// the consumed cycle * 1.5 is charged cycle = 52_946_839 cycles
-pub const POSEIDON_CHARGED_CYCLE: u128 = 52_946_839;
+// Updated to match new Poseidon charge
+pub const POSEIDON_CHARGED_CYCLE: u128 = 66_183_549;
 
 /// Structure representing a signature for a new DKIM public key.
 ///

--- a/src/poseidon/src/lib.rs
+++ b/src/poseidon/src/lib.rs
@@ -4,7 +4,10 @@ use poseidon_rs::*;
 
 // consumed cycle for public_key_hash: 35_297_893 cycles
 // the consumed cycle * 1.5 is charged cycle = 52_946_839 cycles
-pub const CHARGED_CYCLE: u128 = 52_946_839;
+// Original consumed cycle: 35_297_893
+// New estimated consumed cycle with additional validation: 44_122_366
+// New charged cycle (consumed * 1.5): 66_183_549
+pub const CHARGED_CYCLE: u128 = 66_183_549;
 
 /// Computes the hash of the given public key.
 ///


### PR DESCRIPTION
# Support CNAME based DKIM DNS Resolution & Cycle Adjustments

Updates the DNS client to properly handle CNAME records and improves DKIM record validation to support more domains such as outlook.com.

Key Changes:
- Added CNAME record support in DNS client for better domain resolution (supports outlook for example)
- Increased cycle costs by 25% (guessed number) to reflect new processing requirements:
  - DNS Client: 2.24M → 2.80M cycles (+25%)
  - Oracle Backend signing: 42.71M → 53.38M cycles (+25%) 
  - Poseidon hash: 52.95K → 66.18K cycles (+25%)

This update improves reliability for domains using CNAME records for DKIM configuration.