### PR TITLE
Zkfriendly/sol 50 icp cname error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Our repository contains the implementations of theee canisters as follows:
 Our IC DNS oracle backend canister is available at https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=fxmww-qiaaa-aaaaj-azu7a-cai.
 Once you prepare your identity and wallet on ICP, you can obtain the signature for the hash of the public key registered on DNS for the pair of the selector 20230601 and the domain gmail.com by calling the following command:
 ```
-dfx canister call fxmww-qiaaa-aaaaj-azu7a-cai sign_dkim_public_key '("20230601", "gmail.com")'  --network ic --with-cycles 85_414_812_012 --wallet <YOUR_WALLET_CANISTER_ID>
+dfx canister call fxmww-qiaaa-aaaaj-azu7a-cai sign_dkim_public_key '("20230601", "gmail.com")'  --network ic --with-cycles 133_460_643_768 --wallet <YOUR_WALLET_CANISTER_ID>
 ``` 
 
 You can verify it as the ECDSA signature from 0x6293a80bf4bd3fff995a0cab74cbf281d922da02, which is the signer's Ethereum address output by the `get_signer_ethereum_address` function.
@@ -33,10 +33,10 @@ Specifically, each function requires the following amount of cycles.
 
 | Function Name | Required Cycles |
 |---------------|-----------------|
-| public_key_hash | 52_946_839      |
-| get_dkim_public_key | 2_236_193_826 |
-| sign_dkim_public_key | 42_707_406_006 (normal domain) / 85_414_812_012 (domain with gappssmtp.com) |
-| revoke_dkim_public_key | 39_438_456_624 (normal domain) / 78_876_913_248 (domain with gappssmtp.com) |
+| public_key_hash | 82_729_436 |
+| get_dkim_public_key | 3_494_052_853 |
+| sign_dkim_public_key | 66_730_321_884 (normal domain) / 133_460_643_768 (domain with gappssmtp.com) |
+| revoke_dkim_public_key | 61_622_588_475 (normal domain) / 123_245_176_950 (domain with gappssmtp.com) |
 
 ## References
 - [Quick Start](https://internetcomputer.org/docs/quickstart/quickstart-intro)

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,11 +1,11 @@
 {
   "dns_client": {
-    "ic": "oo3c4-gyaaa-aaaaj-azvaa-cai"
+    "ic": "vrvh3-viaaa-aaaaj-az4dq-cai"
   },
   "ic_dns_oracle_backend": {
-    "ic": "fxmww-qiaaa-aaaaj-azu7a-cai"
+    "ic": "u43dv-2aaaa-aaaaj-az4ea-cai"
   },
   "poseidon": {
-    "ic": "fqnqc-5qaaa-aaaaj-azu7q-cai"
+    "ic": "vwubp-yqaaa-aaaaj-az4da-cai"
   }
 }

--- a/src/dns_client/src/lib.rs
+++ b/src/dns_client/src/lib.rs
@@ -17,7 +17,6 @@ const DOMAIN_REGEX: &str =
 
 // Charged cycle for DNS client operations
 pub const CHARGED_CYCLE: u128 = 3_494_052_853;
-const MAX_DNS_DEPTH: usize = 4;
 
 /// Fetches the DKIM public key for the given selector and domain.
 ///
@@ -194,7 +193,9 @@ fn _transform(raw: TransformArgs) -> Result<HttpResponse, String> {
     let mut current_query_name =
         String::from_utf8(raw.context).expect("context is not a valid utf8 string");
 
-    for _ in 0..=MAX_DNS_DEPTH {
+    let mut visited = std::collections::HashSet::new();
+    while !visited.contains(&current_query_name) {
+        visited.insert(current_query_name.clone());
         if let Some(answer) = answers
             .iter()
             .find(|answer| answer["name"].to_string() == current_query_name)

--- a/src/dns_client/src/lib.rs
+++ b/src/dns_client/src/lib.rs
@@ -14,9 +14,8 @@ const SELECTOR_REGEX: &str =
     r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*$";
 const DOMAIN_REGEX: &str =
     r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*$";
-// Original consumed cycle: 1_490_795_884
-// New estimated consumed cycle with CNAME handling: 1_863_494_855
-// New charged cycle (consumed * 1.5): 2_795_242_282
+
+// Charged cycle for DNS client operations
 pub const CHARGED_CYCLE: u128 = 3_494_052_853;
 const MAX_DNS_DEPTH: usize = 4;
 

--- a/src/dns_client/src/lib.rs
+++ b/src/dns_client/src/lib.rs
@@ -17,7 +17,7 @@ const DOMAIN_REGEX: &str =
 // Original consumed cycle: 1_490_795_884
 // New estimated consumed cycle with CNAME handling: 1_863_494_855
 // New charged cycle (consumed * 1.5): 2_795_242_282
-pub const CHARGED_CYCLE: u128 = 2_795_242_282;
+pub const CHARGED_CYCLE: u128 = 3_494_052_853;
 const MAX_DNS_DEPTH: usize = 4;
 
 /// Fetches the DKIM public key for the given selector and domain.

--- a/src/ic_dns_oracle_backend/src/lib.rs
+++ b/src/ic_dns_oracle_backend/src/lib.rs
@@ -9,23 +9,21 @@ use rsa::{pkcs1::DecodeRsaPrivateKey, traits::PublicKeyParts, BigUint, RsaPrivat
 use serde::Deserialize;
 use std::cell::RefCell;
 
-// consumed cycle for _sign_dkim_public_key: 28_471_604_004 cycles
-// the consumed cycle * 1.5 is charged cycle = 42_707_406_006 cycles
-// Note that you need to pay two times of the charged cycle for domains with gappssmtp.com.
-pub const SIGN_CHARGED_CYCLE: u128 = 42_707_406_006;
+// Original consumed cycle: 28_471_604_004
+// New estimated consumed cycle with additional validation: 35_589_505_005
+// New charged cycle (consumed * 1.5): 53_384_257_507
+pub const SIGN_CHARGED_CYCLE: u128 = 53_384_257_507;
 
-// consumed cycle for _revoke_dkim_public_key: 26_292_304_416 cycles
-// the consumed cycle * 1.5 is charged cycle = 39_438_456_624 cycles
-// Note that you need to pay two times of the charged cycle for domains with gappssmtp.com.
-pub const REVOKE_CHARGED_CYCLE: u128 = 39_438_456_624;
+// Original consumed cycle: 26_292_304_416
+// New estimated consumed cycle with additional validation: 32_865_380_520
+// New charged cycle (consumed * 1.5): 49_298_070_780
+pub const REVOKE_CHARGED_CYCLE: u128 = 49_298_070_780;
 
-// consumed cycle for get_dkim_public_key: 1_490_795_884 cycles
-// the consumed cycle * 1.5 is charged cycle = 2_236_193_826 cycles
-pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 2_236_193_826;
+// Updated to match new DNS client charge
+pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 2_795_242_282;
 
-// consumed cycle for public_key_hash: 35_297_893 cycles
-// the consumed cycle * 1.5 is charged cycle = 52_946_839 cycles
-pub const POSEIDON_CHARGED_CYCLE: u128 = 52_946_839;
+// Updated to match new Poseidon charge
+pub const POSEIDON_CHARGED_CYCLE: u128 = 66_183_549;
 
 /// Structure representing a signature for a new DKIM public key.
 ///

--- a/src/ic_dns_oracle_backend/src/lib.rs
+++ b/src/ic_dns_oracle_backend/src/lib.rs
@@ -9,21 +9,17 @@ use rsa::{pkcs1::DecodeRsaPrivateKey, traits::PublicKeyParts, BigUint, RsaPrivat
 use serde::Deserialize;
 use std::cell::RefCell;
 
-// Original consumed cycle: 28_471_604_004
-// New estimated consumed cycle with additional validation: 35_589_505_005
-// New charged cycle (consumed * 1.5): 53_384_257_507
-pub const SIGN_CHARGED_CYCLE: u128 = 53_384_257_507;
+// Charged cycle for signing DKIM public keys
+pub const SIGN_CHARGED_CYCLE: u128 = 66_730_321_884;
 
-// Original consumed cycle: 26_292_304_416
-// New estimated consumed cycle with additional validation: 32_865_380_520
-// New charged cycle (consumed * 1.5): 49_298_070_780
-pub const REVOKE_CHARGED_CYCLE: u128 = 49_298_070_780;
+// Charged cycle for revoking DKIM public keys
+pub const REVOKE_CHARGED_CYCLE: u128 = 61_622_588_475;
 
-// Updated to match new DNS client charge
-pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 2_795_242_282;
+// Charged cycle for DNS client operations
+pub const DNS_CLIENT_CHARGED_CYCLE: u128 = 3_494_052_853;
 
-// Updated to match new Poseidon charge
-pub const POSEIDON_CHARGED_CYCLE: u128 = 66_183_549;
+// Charged cycle for Poseidon hash operations
+pub const POSEIDON_CHARGED_CYCLE: u128 = 82_729_436;
 
 /// Structure representing a signature for a new DKIM public key.
 ///

--- a/src/poseidon/src/lib.rs
+++ b/src/poseidon/src/lib.rs
@@ -4,7 +4,10 @@ use poseidon_rs::*;
 
 // consumed cycle for public_key_hash: 35_297_893 cycles
 // the consumed cycle * 1.5 is charged cycle = 52_946_839 cycles
-pub const CHARGED_CYCLE: u128 = 52_946_839;
+// Original consumed cycle: 35_297_893
+// New estimated consumed cycle with additional validation: 44_122_366
+// New charged cycle (consumed * 1.5): 66_183_549
+pub const CHARGED_CYCLE: u128 = 66_183_549;
 
 /// Computes the hash of the given public key.
 ///

--- a/src/poseidon/src/lib.rs
+++ b/src/poseidon/src/lib.rs
@@ -2,12 +2,8 @@ use ff::PrimeField;
 use hex;
 use poseidon_rs::*;
 
-// consumed cycle for public_key_hash: 35_297_893 cycles
-// the consumed cycle * 1.5 is charged cycle = 52_946_839 cycles
-// Original consumed cycle: 35_297_893
-// New estimated consumed cycle with additional validation: 44_122_366
-// New charged cycle (consumed * 1.5): 66_183_549
-pub const CHARGED_CYCLE: u128 = 66_183_549;
+// Charged cycle for Poseidon hash operations
+pub const CHARGED_CYCLE: u128 = 82_729_436;
 
 /// Computes the hash of the given public key.
 ///


### PR DESCRIPTION
# Support CNAME based DKIM DNS Resolution & Cycle Adjustments

Updates the DNS client to properly handle CNAME records and improves DKIM record validation to support more domains such as outlook.com.

Key Changes:
- Added CNAME record support in DNS client for better domain resolution (supports outlook for example)
- Increased cycle costs (guessed number) to reflect new processing requirements:
  - DNS Client: 2.24M → 3.5M cycles
  - Oracle Backend signing: 42.71M → 66M cycles 
  - Poseidon hash: 52.95K → 82k cycles

This update improves reliability for domains using CNAME records for DKIM configuration.